### PR TITLE
fix: portを数値から文字列に変換して、表示するように修正

### DIFF
--- a/src/DeviceListTable.rb
+++ b/src/DeviceListTable.rb
@@ -3,7 +3,7 @@ require './DeviceManager.rb'
 
 class DeviceListWindow
     include JRubyFX::Controller
-    fxml '../ui/device_list.fxml'
+    fxml 'device_list.fxml'
     module J
         include_package 'javafx.beans.property'
     end
@@ -34,7 +34,7 @@ class DeviceListWindow
 
         def initialize(ip_address, port, connect_state)
             @ip_address = J::SimpleStringProperty.new(ip_address)
-            @port = J::SimpleStringProperty.new(port)
+            @port = J::SimpleStringProperty.new(port.to_s)
             @connect_state = J::SimpleStringProperty.new(connect_state)
         end
     end


### PR DESCRIPTION
JSONに書き込むPortの値がStringではなくなったため、SimpleStringPropertyでエラーとなっていた。
SimpleStringPropertyに文字列データとして渡すために数値データを文字列に変換するように修正
