### PR TITLE
remove:JsonWriterを削除

### DIFF
--- a/src/DeviceJsonWriter.rb
+++ b/src/DeviceJsonWriter.rb
@@ -1,7 +1,14 @@
+require 'json'
 require_relative './JsonWriter.rb'
 require_relative './AdbDevice.rb'
 
-class DeviceJsonWriter < JsonWriter
+class DeviceJsonWriter
+    def writeFile(path, json_data)
+        open(path, 'w') do |io|
+            JSON.dump(json_data, io)
+        end
+    end
+
     def writeDeviceData(devices)
         device_data = []
         devices.each do |device|

--- a/src/JsonWriter.rb
+++ b/src/JsonWriter.rb
@@ -1,8 +1,0 @@
-require 'json'
-class JsonWriter
-    def writeFile(path, json_data)
-        open(path, 'w') do |io|
-            JSON.dump(json_data, io)
-        end
-    end
-end


### PR DESCRIPTION
DeviceJsonWriterがJsonWriterを継承するつくりは冗長であるため削除
